### PR TITLE
Fix responseFormatter test mocks to include OutputFormat export

### DIFF
--- a/test/responseFormatter.test.ts
+++ b/test/responseFormatter.test.ts
@@ -12,20 +12,26 @@ vi.mock('../src/utils/logger', async () => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-      debug: vi.fn()
+      debug: vi.fn(),
     },
     logger: {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-      debug: vi.fn()
-    }
+      debug: vi.fn(),
+    },
   };
 });
 
 // Mock output processor
 vi.mock('../src/utils/outputProcessor', () => {
   return {
+    OutputFormat: {
+      TEXT: 'text',
+      JSON: 'json',
+      TABLE: 'table',
+      CHART: 'chart',
+    },
     default: {
       processOutput: vi.fn().mockImplementation((output) => {
         if (output === null || output === undefined) {
@@ -33,36 +39,36 @@ vi.mock('../src/utils/outputProcessor', () => {
             summary: 'Error processing output',
             highlights: [],
             formatted: output,
-            raw: String(output)
+            raw: String(output),
           };
         }
         return {
           summary: typeof output === 'string' ? output.substring(0, 100) : 'Processed output',
           highlights: ['Important line 1', 'Important line 2'],
           formatted: output,
-          raw: output
+          raw: output,
         };
       }),
-      extractHighlights: vi.fn().mockReturnValue(['Important line 1', 'Important line 2'])
-    }
+      extractHighlights: vi.fn().mockReturnValue(['Important line 1', 'Important line 2']),
+    },
   };
 });
 
 describe('Response Formatter', () => {
   vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
   let responseFormatter: ResponseFormatter;
-  
+
   beforeEach(() => {
     responseFormatter = new ResponseFormatter();
     vi.clearAllMocks();
-    
+
     // Mock Date.now() to return a fixed timestamp
     const mockDate = new Date('2023-01-01T12:00:00Z');
     vi.spyOn(global, 'Date').mockImplementation(() => mockDate);
   });
-  
+
   describe('formatSuccess', () => {
-  vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
+    vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
     it('should format a successful response', () => {
       const id = 'test-id';
       const type = 'test.type';
@@ -73,19 +79,19 @@ describe('Response Formatter', () => {
           key1: 'value1',
           key2: 42,
           nested: {
-            nestedKey: 'nestedValue'
-          }
-        }
+            nestedKey: 'nestedValue',
+          },
+        },
       };
       const options = {
         serverVersion: '1.0.0',
         openStudioVersion: '3.5.0',
         includeMetadata: true,
-        includeRawOutput: true
+        includeRawOutput: true,
       };
-      
+
       const response = responseFormatter.formatSuccess(id, type, result, options);
-      
+
       expect(response.id).toBe(id);
       expect(response.type).toBe(type);
       expect(response.status).toBe('success');
@@ -98,24 +104,24 @@ describe('Response Formatter', () => {
       expect(response.result._metadata.serverVersion).toBe('1.0.0');
       expect(response.result._metadata.openStudioVersion).toBe('3.5.0');
     });
-    
+
     it('should format a successful response without metadata', () => {
       const id = 'test-id';
       const type = 'test.type';
       const result: CommandResult = {
         success: true,
         output: 'Command executed successfully',
-        data: { key: 'value' }
+        data: { key: 'value' },
       };
       const options = {
         serverVersion: '1.0.0',
         openStudioVersion: '3.5.0',
         includeMetadata: false,
-        includeRawOutput: true
+        includeRawOutput: true,
       };
-      
+
       const response = responseFormatter.formatSuccess(id, type, result, options);
-      
+
       expect(response.id).toBe(id);
       expect(response.type).toBe(type);
       expect(response.status).toBe('success');
@@ -124,24 +130,24 @@ describe('Response Formatter', () => {
       expect(response.result.output).toBe('Command executed successfully');
       expect(response.result._metadata).toBeUndefined();
     });
-    
+
     it('should format a successful response without raw output', () => {
       const id = 'test-id';
       const type = 'test.type';
       const result: CommandResult = {
         success: true,
         output: 'Command executed successfully',
-        data: { key: 'value' }
+        data: { key: 'value' },
       };
       const options = {
         serverVersion: '1.0.0',
         openStudioVersion: '3.5.0',
         includeMetadata: true,
-        includeRawOutput: false
+        includeRawOutput: false,
       };
-      
+
       const response = responseFormatter.formatSuccess(id, type, result, options);
-      
+
       expect(response.id).toBe(id);
       expect(response.type).toBe(type);
       expect(response.status).toBe('success');
@@ -150,30 +156,30 @@ describe('Response Formatter', () => {
       expect(response.result.output).toBeUndefined();
       expect(response.result._metadata).toBeDefined();
     });
-    
+
     it('should process output if requested', () => {
       const id = 'test-id';
       const type = 'test.type';
       const result: CommandResult = {
         success: true,
         output: 'Command executed successfully with some technical details',
-        data: { key: 'value' }
+        data: { key: 'value' },
       };
       const options = {
         processOutput: true,
-        includeHighlights: true
+        includeHighlights: true,
       };
-      
+
       const response = responseFormatter.formatSuccess(id, type, result, options);
-      
+
       expect(response.result.processedOutput).toBeDefined();
       expect(response.result.processedOutput.summary).toBeDefined();
       // Highlights might be undefined depending on implementation
     });
   });
-  
+
   describe('formatError', () => {
-  vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
+    vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
     it('should format an error response', () => {
       const id = 'test-id';
       const type = 'test.type';
@@ -184,11 +190,11 @@ describe('Response Formatter', () => {
         serverVersion: '1.0.0',
         openStudioVersion: '3.5.0',
         includeMetadata: true,
-        includeRawOutput: true
+        includeRawOutput: true,
       };
-      
+
       const response = responseFormatter.formatError(id, type, message, code, details, options);
-      
+
       expect(response.id).toBe(id);
       expect(response.type).toBe(type);
       expect(response.status).toBe('error');
@@ -200,7 +206,7 @@ describe('Response Formatter', () => {
       expect(response.error._metadata.serverVersion).toBe('1.0.0');
       expect(response.error._metadata.openStudioVersion).toBe('3.5.0');
     });
-    
+
     it('should format an error response without metadata', () => {
       const id = 'test-id';
       const type = 'test.type';
@@ -211,11 +217,11 @@ describe('Response Formatter', () => {
         serverVersion: '1.0.0',
         openStudioVersion: '3.5.0',
         includeMetadata: false,
-        includeRawOutput: true
+        includeRawOutput: true,
       };
-      
+
       const response = responseFormatter.formatError(id, type, message, code, details, options);
-      
+
       expect(response.id).toBe(id);
       expect(response.type).toBe(type);
       expect(response.status).toBe('error');
@@ -225,18 +231,18 @@ describe('Response Formatter', () => {
       expect(response.error.details).toEqual(details);
       expect(response.error._metadata).toBeUndefined();
     });
-    
+
     it('should handle Error objects', () => {
       const id = 'test-id';
       const type = 'test.type';
       const error = new Error('Test error message');
       const code = 'TEST_ERROR';
-      
+
       const response = responseFormatter.formatError(id, type, error, code);
-      
+
       expect(response.error.message).toBe('Test error message');
     });
-    
+
     it('should process error message if requested', () => {
       const id = 'test-id';
       const type = 'test.type';
@@ -244,11 +250,18 @@ describe('Response Formatter', () => {
       const code = 'TEST_ERROR';
       const options = {
         processOutput: true,
-        includeHighlights: true
+        includeHighlights: true,
       };
-      
-      const response = responseFormatter.formatError(id, type, message, code, { originalMessage: message }, options);
-      
+
+      const response = responseFormatter.formatError(
+        id,
+        type,
+        message,
+        code,
+        { originalMessage: message },
+        options,
+      );
+
       expect(response.error.message).toBeDefined();
       // The details might be undefined or contain highlights depending on the implementation
       if (response.error.details && response.error.details.highlights) {
@@ -256,63 +269,63 @@ describe('Response Formatter', () => {
       }
     });
   });
-  
+
   describe('formatResponse', () => {
-  vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
+    vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
     it('should format a successful command result', () => {
       const id = 'test-id';
       const type = 'test.type';
       const result: CommandResult = {
         success: true,
         output: 'Command executed successfully',
-        data: { key: 'value' }
+        data: { key: 'value' },
       };
-      
+
       const response = responseFormatter.formatResponse(id, type, result);
-      
+
       expect(response.status).toBe('success');
       expect(response.result).toBeDefined();
     });
-    
+
     it('should format a failed command result', () => {
       const id = 'test-id';
       const type = 'test.type';
       const result: CommandResult = {
         success: false,
         output: '',
-        error: 'Command execution failed'
+        error: 'Command execution failed',
       };
-      
+
       const response = responseFormatter.formatResponse(id, type, result);
-      
+
       expect(response.status).toBe('error');
       expect(response.error).toBeDefined();
       expect(response.error.message).toBe('Command execution failed');
     });
   });
-  
+
   describe('addMetadata', () => {
-  vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
+    vi.setConfig({ testTimeout: 10000 }); // Added 10s timeout
     it('should add metadata to a success response', () => {
       const response = {
         id: 'test-id',
         type: 'test.type',
         status: 'success',
-        result: { key: 'value' }
+        result: { key: 'value' },
       };
-      
+
       const metadata = {
         timestamp: '2023-01-01T12:00:00Z',
-        serverVersion: '1.0.0'
+        serverVersion: '1.0.0',
       };
-      
+
       const updatedResponse = responseFormatter.addMetadata(response, metadata);
-      
+
       expect(updatedResponse.result._metadata).toBeDefined();
       expect(updatedResponse.result._metadata.timestamp).toBe('2023-01-01T12:00:00Z');
       expect(updatedResponse.result._metadata.serverVersion).toBe('1.0.0');
     });
-    
+
     it('should add metadata to an error response', () => {
       const response = {
         id: 'test-id',
@@ -320,22 +333,22 @@ describe('Response Formatter', () => {
         status: 'error',
         error: {
           code: 'TEST_ERROR',
-          message: 'Test error'
-        }
+          message: 'Test error',
+        },
       };
-      
+
       const metadata = {
         timestamp: '2023-01-01T12:00:00Z',
-        serverVersion: '1.0.0'
+        serverVersion: '1.0.0',
       };
-      
+
       const updatedResponse = responseFormatter.addMetadata(response, metadata);
-      
+
       expect(updatedResponse.error._metadata).toBeDefined();
       expect(updatedResponse.error._metadata.timestamp).toBe('2023-01-01T12:00:00Z');
       expect(updatedResponse.error._metadata.serverVersion).toBe('1.0.0');
     });
-    
+
     it('should merge with existing metadata', () => {
       const response = {
         id: 'test-id',
@@ -344,17 +357,17 @@ describe('Response Formatter', () => {
         result: {
           key: 'value',
           _metadata: {
-            existingKey: 'existingValue'
-          }
-        }
+            existingKey: 'existingValue',
+          },
+        },
       };
-      
+
       const metadata = {
-        newKey: 'newValue'
+        newKey: 'newValue',
       };
-      
+
       const updatedResponse = responseFormatter.addMetadata(response, metadata);
-      
+
       expect(updatedResponse.result._metadata.existingKey).toBe('existingValue');
       expect(updatedResponse.result._metadata.newKey).toBe('newValue');
     });


### PR DESCRIPTION
## Summary
Fixes failing tests in `responseFormatter.test.ts` by properly mocking the `OutputFormat` enum export from the `outputProcessor` module.

## Problem
Two tests were failing with the error:
```
Error: [vitest] No "OutputFormat" export is defined on the "../src/utils/outputProcessor" mock. Did you forget to return it from "vi.mock"?
```

## Solution
- Added `OutputFormat` enum to the mock export in `test/responseFormatter.test.ts`
- The mock now properly exports both the default object and the `OutputFormat` enum

## Tests Fixed
- ✅ `should process output if requested`
- ✅ `should process error message if requested`

## Verification
- All tests now pass: `npm test` ✅
- No breaking changes to existing functionality
- Mock maintains the same behavior for all other tests

Closes #4