### PR TITLE
fix: Update CI workflows to use 'main' branch instead of 'master'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -2,9 +2,9 @@ name: Debug CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   debug:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -2,9 +2,9 @@ name: Minimal CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/skip-ci.yml
+++ b/.github/workflows/skip-ci.yml
@@ -2,9 +2,9 @@ name: Skip CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   skip:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm run dev
 
 This project uses GitHub Actions for continuous integration and deployment:
 
-- **CI Workflow**: Automatically runs linting, building, and testing on push to master and pull requests
+- **CI Workflow**: Automatically runs linting, building, and testing on push to main and pull requests
 - **Release Workflow**: Automatically builds and packages the application when a new version tag is pushed
 - **Docker Workflow**: Builds and publishes Docker images to GitHub Container Registry
 - **Dependency Review**: Scans dependencies for security vulnerabilities on pull requests


### PR DESCRIPTION
## Summary

This PR fixes the CI workflow triggers that were still referencing the old 'master' branch name.

## Changes Made

- Updated all GitHub Actions workflows (.github/workflows/*.yml) to trigger on 'main' branch instead of 'master'
- Updated README.md documentation to reflect 'main' branch usage in CI/CD section

## Files Modified

- 
-  
- 
- 
- 
- 

## Impact

- CI workflows will now properly trigger on pushes and pull requests to the 'main' branch
- Documentation accurately reflects the current branch naming convention
- Resolves any CI workflow trigger issues related to the branch name change

## Testing

- [x] Verified all workflow files use consistent 'main' branch references
- [x] Confirmed no other files contain 'master' branch references
- [x] Updated documentation matches the actual CI configuration

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>